### PR TITLE
Implement dispersion control

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Within the sketch you can call `saveFrame("frame-####.png");` to write screensho
 ## ⚙️ Technical notes
 
 * **Accurate refraction offset**
-  Refracted ray intersects a distant plane (background) and offsets UVs from the
-  current screen coordinate.
+  Rays refract on entry and exit of the bubble then intersect a distant plane to
+  determine the background UV shift.
 * **Dispersion** sampled at three wavelengths (R/G/B) using slightly different IOR values (1.333 / 1.340 / 1.348).
 * **Thin‑film** interference uses the glTF `KHR_materials_iridescence` 3‑wavelength cosine approximation.
 * **Warp strength** ≈ `warpScale × (farPlane − lensDepth)/farPlane` so perspective and scene depth influence distortion.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
   * Thin‑film interference for rainbow colours
   * Subtle GGX rim highlights adjustable with `roughness`
   * Optional curl‑noise wobble for *Liquid Glass* feel (default gentle 0.10)
-* Background is a static image (`windows.jpg`) drawn each frame.
+* Background is a static image (`windows.jpg`) drawn each frame and also passed
+  to the shader as `bgTex` so refraction can warp it.
 * All material parameters are tweakable **via simple keyboard shortcuts** – no GUI library needed.
 
 ---
@@ -57,6 +58,8 @@ A live HUD at the bottom‑left shows current values.
 2. Clone / copy this folder.
 3. Place a background JPG named `windows.jpg` inside **data/** (any 16:9 image works).
 4. Open `HoloBubbleWarp.pde` in Processing and press **Run**.
+5. The sketch loads this image and binds it to the shader uniform `bgTex` so the
+   refraction logic can distort the background.
 
 No additional libraries are required; the sketch relies only on standard P3D and GLSL 1.50.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Within the sketch you can call `saveFrame("frame-####.png");` to write screensho
 ## ⚙️ Technical notes
 
 * **Accurate refraction offset**
-  Ray–sphere intersection in view space → project exit point to screen → clamp UV.
+  Refracted ray intersects a distant plane (background) and offsets UVs from the
+  original view ray.
 * **Dispersion** sampled at three wavelengths (R/G/B) using slightly different IOR values (1.333 / 1.340 / 1.348).
 * **Thin‑film** interference uses the glTF `KHR_materials_iridescence` 3‑wavelength cosine approximation.
 * **Warp strength** = `warpScale × (farPlane − lensDepth)` ensures larger fov/scene depths create bolder distortion.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
   * RGB‑wise Snell refraction → large‐scale background warp
   * Thin‑film interference for rainbow colours
-  * Subtle GGX rim highlights (`roughness`)
+  * Subtle GGX rim highlights adjustable with `roughness`
   * Optional curl‑noise wobble for *Liquid Glass* feel (default gentle 0.10)
 * Background is a static image (`windows.jpg`) drawn each frame.
 * All material parameters are tweakable **via simple keyboard shortcuts** – no GUI library needed.

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Within the sketch you can call `saveFrame("frame-####.png");` to write screensho
 
 * **Accurate refraction offset**
   Refracted ray intersects a distant plane (background) and offsets UVs from the
-  original view ray.
+  current screen coordinate.
 * **Dispersion** sampled at three wavelengths (R/G/B) using slightly different IOR values (1.333 / 1.340 / 1.348).
 * **Thin‑film** interference uses the glTF `KHR_materials_iridescence` 3‑wavelength cosine approximation.
-* **Warp strength** = `warpScale × (farPlane − lensDepth)` ensures larger fov/scene depths create bolder distortion.
+* **Warp strength** ≈ `warpScale × (farPlane − lensDepth)/farPlane` so perspective and scene depth influence distortion.
 * **Curl‑noise wobble** (P\_Malin *Liquid Glass* method) adds subtle spatial‑temporal variation; set `noiseAmp` → 0 to disable.
 
 ---

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ A live HUD at the bottom‑left shows current values.
 4. Open `HoloBubbleWarp.pde` in Processing and press **Run**.
 5. The sketch loads this image and binds it to the shader uniform `bgTex` so the
    refraction logic can distort the background.
+6. The bubble mesh is rendered to an off‑screen buffer (`warpBuf`) so its warped
+   pixels fully replace the image behind them.
 
 No additional libraries are required; the sketch relies only on standard P3D and GLSL 1.50.
 
@@ -85,6 +87,12 @@ Within the sketch you can call `saveFrame("frame-####.png");` to write screensho
 * **Accurate refraction offset**
   Rays refract on entry and exit of the bubble then intersect a distant plane to
   determine the background UV shift.
+  Steps performed in the fragment shader:
+  1. Build the view ray from the current fragment.
+  2. Refract that ray as it enters the bubble.
+  3. Intersect the inner surface and refract back out to air.
+  4. Project both the original and refracted rays to a far plane.
+  5. Convert their difference to a screen‑space UV offset and sample `bgTex`.
 * **Dispersion** sampled at three wavelengths (R/G/B) using slightly different IOR values (1.333 / 1.340 / 1.348).
 * **Thin‑film** interference uses the glTF `KHR_materials_iridescence` 3‑wavelength cosine approximation.
 * **Warp strength** ≈ `warpScale × (farPlane − lensDepth)/farPlane` so perspective and scene depth influence distortion.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ HoloBubbleWarp/
 | **W / S** | Projection distance (*farPlane*) ±2 | 8 – 40       | **20**      |
 | **Y / H** | Warp scale multiplier ±0.2          | 0.5 – 4      | **1.5**     |
 | **U / J** | Noise amplitude ±0.02               | 0 – 0.3      | **0.10**    |
+| **K / L** | Dispersion strength ±0.1            | 0 – 2        | **1.0**     |
 | **R / E** | Roughness ±0.02                     | 0 – 0.4      | **0.12**    |
+| **P**     | Save screenshot                     | –            | –           |
 
 A live HUD at the bottom‑left shows current values.
 
@@ -57,6 +59,21 @@ A live HUD at the bottom‑left shows current values.
 4. Open `HoloBubbleWarp.pde` in Processing and press **Run**.
 
 No additional libraries are required; the sketch relies only on standard P3D and GLSL 1.50.
+
+### Command‑line usage
+
+1. In the Processing IDE choose **Tools → Install "processing‑java"** to install the CLI helper.
+2. Run the sketch from a terminal:
+
+   ```bash
+   processing-java --sketch=/path/to/sketch_250701a --run
+   ```
+
+   When running headless (e.g. on a server) you may need a virtual display such as **Xvfb**.
+
+### Capturing frames
+
+Within the sketch you can call `saveFrame("frame-####.png");` to write screenshots. Pressing **Ctrl+S** (or `Cmd+S` on macOS) while the sketch window is focused also saves an image to the sketch folder.
 
 ---
 

--- a/data/holo.frag
+++ b/data/holo.frag
@@ -30,17 +30,23 @@ void main(){
   vec3 Rg=refract(I,N,1.0/eta.g);
   vec3 Rb=refract(I,N,1.0/eta.b);
 
-  vec3 P=vPosV; float r=lensDepth;
-  float tr=-dot(P,Rr)+sqrt(max(dot(P,Rr)*dot(P,Rr)-(dot(P,P)-r*r),0));
-  float tg=-dot(P,Rg)+sqrt(max(dot(P,Rg)*dot(P,Rg)-(dot(P,P)-r*r),0));
-  float tb=-dot(P,Rb)+sqrt(max(dot(P,Rb)*dot(P,Rb)-(dot(P,P)-r*r),0));
-  vec3 Qr=P+Rr*tr, Qg=P+Rg*tg, Qb=P+Rb*tb;
+  vec3 P=vPosV;
+  float tBase=(-farPlane - P.z)/I.z;
+  vec3 basePos=P+I*tBase;
+  vec2 base=basePos.xy/(-farPlane); base=base*0.5/resolution.y+0.5;
 
-  /* screen projection */
-  vec2 base=(I.xy/I.z)*(-farPlane); base=base*0.5/resolution.y+0.5;
-  vec2 uvR=clamp(base + (Qr.xy/Qr.z - I.xy/I.z)*warpScale*0.5,0.002,0.998);
-  vec2 uvG=clamp(base + (Qg.xy/Qg.z - I.xy/I.z)*warpScale*0.5,0.002,0.998);
-  vec2 uvB=clamp(base + (Qb.xy/Qb.z - I.xy/I.z)*warpScale*0.5,0.002,0.998);
+  float tR=(-farPlane - P.z)/Rr.z;
+  float tG=(-farPlane - P.z)/Rg.z;
+  float tB=(-farPlane - P.z)/Rb.z;
+  vec3 Qr=P+Rr*tR, Qg=P+Rg*tG, Qb=P+Rb*tB;
+
+  vec2 diffR=(Qr.xy-basePos.xy)/(-farPlane);
+  vec2 diffG=(Qg.xy-basePos.xy)/(-farPlane);
+  vec2 diffB=(Qb.xy-basePos.xy)/(-farPlane);
+  float w = warpScale*(farPlane-lensDepth);
+  vec2 uvR=clamp(base + diffR*w,0.002,0.998);
+  vec2 uvG=clamp(base + diffG*w,0.002,0.998);
+  vec2 uvB=clamp(base + diffB*w,0.002,0.998);
 
   vec3 refr=vec3(texture(bgTex,uvR).r, texture(bgTex,uvG).g, texture(bgTex,uvB).b);
   vec3 film=irid(1.33,thinFilmBase,cv)*0.85;

--- a/data/holo.frag
+++ b/data/holo.frag
@@ -1,5 +1,5 @@
 #version 150
-uniform float thinFilmBase, roughness, alpha, lensDepth, farPlane, warpScale, noiseAmp, time;
+uniform float thinFilmBase, roughness, alpha, lensDepth, farPlane, warpScale, noiseAmp, dispersion, time;
 uniform sampler2D bgTex;
 uniform vec2 resolution;
 
@@ -23,7 +23,9 @@ void main(){
   vec3 V = normalize(vV); vec3 I=-V; float cv=sat(dot(N,V));
 
   /* dispersion directions */
-  vec3 eta=vec3(1.333,1.340,1.348);
+  vec3 eta=vec3(1.333,
+                 1.333 + 0.007*dispersion,
+                 1.333 + 0.015*dispersion);
   vec3 Rr=refract(I,N,1.0/eta.r);
   vec3 Rg=refract(I,N,1.0/eta.g);
   vec3 Rb=refract(I,N,1.0/eta.b);

--- a/data/holo.frag
+++ b/data/holo.frag
@@ -33,7 +33,7 @@ void main(){
   vec3 P=vPosV;
   float tBase=(-farPlane - P.z)/I.z;
   vec3 basePos=P+I*tBase;
-  vec2 base=basePos.xy/(-farPlane); base=base*0.5/resolution.y+0.5;
+  vec2 base=gl_FragCoord.xy/resolution;
 
   float tR=(-farPlane - P.z)/Rr.z;
   float tG=(-farPlane - P.z)/Rg.z;
@@ -43,7 +43,7 @@ void main(){
   vec2 diffR=(Qr.xy-basePos.xy)/(-farPlane);
   vec2 diffG=(Qg.xy-basePos.xy)/(-farPlane);
   vec2 diffB=(Qb.xy-basePos.xy)/(-farPlane);
-  float w = warpScale*(farPlane-lensDepth);
+  float w = warpScale*(farPlane-lensDepth)/farPlane;
   vec2 uvR=clamp(base + diffR*w,0.002,0.998);
   vec2 uvG=clamp(base + diffG*w,0.002,0.998);
   vec2 uvB=clamp(base + diffB*w,0.002,0.998);

--- a/data/holo.frag
+++ b/data/holo.frag
@@ -50,7 +50,8 @@ void main(){
 
   vec3 refr=vec3(texture(bgTex,uvR).r, texture(bgTex,uvG).g, texture(bgTex,uvB).b);
   vec3 film=irid(1.33,thinFilmBase,cv)*0.85;
-  vec3 spec=F(cv,vec3(0.04))*0.15;
+  float width=mix(4.0,1.0,roughness*2.5);
+  vec3 spec=F(cv,vec3(0.04))*pow(1.0-cv,width)*0.5;
 
   vec3 col=pow((refr+film+spec)/(refr+film+spec+1.0), vec3(1.0/2.2));
   fragColor=vec4(sat(col), alpha);

--- a/data/holo.frag
+++ b/data/holo.frag
@@ -26,19 +26,34 @@ void main(){
   vec3 eta=vec3(1.333,
                  1.333 + 0.007*dispersion,
                  1.333 + 0.015*dispersion);
-  vec3 Rr=refract(I,N,1.0/eta.r);
-  vec3 Rg=refract(I,N,1.0/eta.g);
-  vec3 Rb=refract(I,N,1.0/eta.b);
-
   vec3 P=vPosV;
+  float r=lensDepth;
+
+  /* refract into the bubble */
+  vec3 I0r=refract(I,N,1.0/eta.r);
+  vec3 I0g=refract(I,N,1.0/eta.g);
+  vec3 I0b=refract(I,N,1.0/eta.b);
+
+  /* intersect inner surface and refract back to air */
+  float tr=-dot(P,I0r)+sqrt(max(dot(P,I0r)*dot(P,I0r)-(dot(P,P)-r*r),0.0));
+  float tg=-dot(P,I0g)+sqrt(max(dot(P,I0g)*dot(P,I0g)-(dot(P,P)-r*r),0.0));
+  float tb=-dot(P,I0b)+sqrt(max(dot(P,I0b)*dot(P,I0b)-(dot(P,P)-r*r),0.0));
+  vec3 Pr=P+I0r*tr, Pg=P+I0g*tg, Pb=P+I0b*tb;
+
+  vec3 Nr=normalize(Pr), Ng=normalize(Pg), Nb=normalize(Pb);
+  vec3 Rr=refract(I0r,Nr,eta.r);
+  vec3 Rg=refract(I0g,Ng,eta.g);
+  vec3 Rb=refract(I0b,Nb,eta.b);
+
+  /* projection to far plane */
   float tBase=(-farPlane - P.z)/I.z;
   vec3 basePos=P+I*tBase;
   vec2 base=gl_FragCoord.xy/resolution;
 
-  float tR=(-farPlane - P.z)/Rr.z;
-  float tG=(-farPlane - P.z)/Rg.z;
-  float tB=(-farPlane - P.z)/Rb.z;
-  vec3 Qr=P+Rr*tR, Qg=P+Rg*tG, Qb=P+Rb*tB;
+  float tR=(-farPlane - Pr.z)/Rr.z;
+  float tG=(-farPlane - Pg.z)/Rg.z;
+  float tB=(-farPlane - Pb.z)/Rb.z;
+  vec3 Qr=Pr+Rr*tR, Qg=Pg+Rg*tG, Qb=Pb+Rb*tB;
 
   vec2 diffR=(Qr.xy-basePos.xy)/(-farPlane);
   vec2 diffG=(Qg.xy-basePos.xy)/(-farPlane);

--- a/sketch_250701a.pde
+++ b/sketch_250701a.pde
@@ -7,6 +7,7 @@ PImage  bg;
 /* parameters */
 float thin = 1.0f, rough = 0.12f, alpha = 0.35f;
 float depth = 2.0f, farP = 20.0f, warpScale = 1.5f, noiseAmp = 0.10f;
+float dispersion = 1.0f;
 boolean useBox = true, useIco = false;
 
 void settings(){ size(900,650,P3D); }
@@ -30,6 +31,7 @@ void draw(){
   holo.set("farPlane",farP);
   holo.set("warpScale",warpScale);
   holo.set("noiseAmp",noiseAmp);
+  holo.set("dispersion",dispersion);
   holo.set("time",millis()*0.001f);
 
   beginBlend(); shader(holo);
@@ -51,8 +53,8 @@ void hud(){
   fill(255); textSize(12);
   String sh=useBox?"BOX":useIco?"ICO":"SPHERE";
   text(String.format(
-    "%s  α=%.2f thin=%.2fµm depth=%.2f far=%.0f scale=%.1f noise=%.2f rough=%.2f",
-    sh,alpha,thin,depth,farP,warpScale,noiseAmp,rough),10,height-10);
+    "%s  α=%.2f thin=%.2fµm depth=%.2f far=%.0f scale=%.1f noise=%.2f rough=%.2f disp=%.1f",
+    sh,alpha,thin,depth,farP,warpScale,noiseAmp,rough,dispersion),10,height-10);
   hint(ENABLE_DEPTH_TEST);
 }
 
@@ -60,20 +62,23 @@ void keyPressed(){
   switch(key){
     case ' ': useBox=!useBox; useIco=false; updateGeom(); break;
     case 'i': case 'I': useIco=!useIco; useBox=false; updateGeom(); break;
-    case 'a': case 'A': alpha = constrain(alpha+0.05,0,1); break;
-    case 'z': case 'Z': alpha = constrain(alpha-0.05,0,1); break;
-    case 't': case 'T': thin  = constrain(thin +0.05,0.3,1.5); break;
-    case 'g': case 'G': thin  = constrain(thin -0.05,0.3,1.5); break;
-    case 'd': case 'D': depth = constrain(depth+0.15,1,4); break;
-    case 'f': case 'F': depth = constrain(depth-0.15,1,4); break;
-    case 'w': case 'W': farP  = constrain(farP +2,8,40); break;
-    case 's': case 'S': farP  = constrain(farP -2,8,40); break;
-    case 'y': case 'Y': warpScale=constrain(warpScale+0.2,0.5,4); break;
-    case 'h': case 'H': warpScale=constrain(warpScale-0.2,0.5,4); break;
-    case 'u': case 'U': noiseAmp = constrain(noiseAmp+0.02,0,0.3); break;
-    case 'j': case 'J': noiseAmp = constrain(noiseAmp-0.02,0,0.3); break;
-    case 'r':           rough = constrain(rough+0.02,0,0.4); break;
-    case 'e':           rough = constrain(rough-0.02,0,0.4); break;
+    case 'a': case 'A': alpha = constrain(alpha+0.05f,0f,1f); break;
+    case 'z': case 'Z': alpha = constrain(alpha-0.05f,0f,1f); break;
+    case 't': case 'T': thin  = constrain(thin +0.05f,0.3f,1.5f); break;
+    case 'g': case 'G': thin  = constrain(thin -0.05f,0.3f,1.5f); break;
+    case 'd': case 'D': depth = constrain(depth+0.15f,1f,4f); break;
+    case 'f': case 'F': depth = constrain(depth-0.15f,1f,4f); break;
+    case 'w': case 'W': farP  = constrain(farP +2f,8f,40f); break;
+    case 's': case 'S': farP  = constrain(farP -2f,8f,40f); break;
+    case 'y': case 'Y': warpScale=constrain(warpScale+0.2f,0.5f,4f); break;
+    case 'h': case 'H': warpScale=constrain(warpScale-0.2f,0.5f,4f); break;
+    case 'u': case 'U': noiseAmp = constrain(noiseAmp+0.02f,0f,0.3f); break;
+    case 'j': case 'J': noiseAmp = constrain(noiseAmp-0.02f,0f,0.3f); break;
+    case 'k': case 'K': dispersion = constrain(dispersion+0.1f,0f,2f); break;
+    case 'l': case 'L': dispersion = constrain(dispersion-0.1f,0f,2f); break;
+    case 'r':           rough = constrain(rough+0.02f,0f,0.4f); break;
+    case 'e':           rough = constrain(rough-0.02f,0f,0.4f); break;
+    case 'p': case 'P': saveFrame("frame-####.png"); break;
   }
 }
 

--- a/sketch_250701a.pde
+++ b/sketch_250701a.pde
@@ -33,6 +33,7 @@ void draw(){
   holo.set("noiseAmp",noiseAmp);
   holo.set("dispersion",dispersion);
   holo.set("time",millis()*0.001f);
+  holo.set("bgTex",bg); // ensure background texture is bound every frame
 
   beginBlend(); shader(holo);
   pushMatrix();

--- a/sketch_250701a.pde
+++ b/sketch_250701a.pde
@@ -3,6 +3,7 @@ import processing.opengl.*;
 PShape geom;
 PShader holo;
 PImage  bg;
+PGraphics warpBuf;
 
 /* parameters */
 float thin = 1.0f, rough = 0.12f, alpha = 0.35f;
@@ -16,6 +17,9 @@ void setup(){
   surface.setTitle("Warp Bubble  –  SPACE I  A/Z T/G D/F W/S Y/H U/J R/E");
   noStroke(); updateGeom();
   bg = loadImage("windows.jpg"); bg.resize(width,height);
+
+  warpBuf = createGraphics(width, height, P3D);
+  warpBuf.noStroke();
 
   holo = loadShader("holo.frag","holo.vert");
   holo.set("bgTex",bg); holo.set("resolution",(float)width,(float)height);
@@ -35,19 +39,23 @@ void draw(){
   holo.set("time",millis()*0.001f);
   holo.set("bgTex",bg); // ensure background texture is bound every frame
 
-  beginBlend(); shader(holo);
-  pushMatrix();
-    translate(width*0.5f, height*0.55f);
-    rotateY(frameCount*0.006f); rotateX(frameCount*0.004f);
-    shape(geom);
-  popMatrix(); resetShader(); endBlend();
+  warpBuf.beginDraw();
+  warpBuf.background(0,0);
+  warpBuf.shader(holo);
+  warpBuf.pushMatrix();
+    warpBuf.translate(width*0.5f, height*0.55f);
+    warpBuf.rotateY(frameCount*0.006f);
+    warpBuf.rotateX(frameCount*0.004f);
+    warpBuf.shape(geom);
+  warpBuf.popMatrix();
+  warpBuf.resetShader();
+  warpBuf.endDraw();
+
+  image(warpBuf,0,0);
 
   hud();
 }
 
-void beginBlend(){ PGL g=beginPGL(); g.enable(PGL.BLEND);
-  g.blendFunc(PGL.SRC_ALPHA,PGL.ONE_MINUS_SRC_ALPHA); endPGL(); }
-void endBlend(){ PGL g=beginPGL(); g.disable(PGL.BLEND); endPGL(); }
 
 void hud(){
   hint(DISABLE_DEPTH_TEST);


### PR DESCRIPTION
## Summary
- add shader uniform for dispersion
- expose dispersion via K/L keys
- document screenshot shortcut

## Testing
- `java -cp "/tmp/processing/Processing/lib/app/*" processing.mode.java.Commander --help | head`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864968d9c988327b03f092545f28344